### PR TITLE
delete instead of truncate for sqlreport_supershares

### DIFF
--- a/sql/update_supersharer.sql
+++ b/sql/update_supersharer.sql
@@ -1,5 +1,5 @@
 -- update signatures
-TRUNCATE TABLE sqlreport_supershares;
+DELETE FROM sqlreport_supershares;
 INSERT INTO sqlreport_supershares (entity_id, counter)
   SELECT
     sh.entity_id, count(a.id) counter


### PR DESCRIPTION
similar to https://trello.com/c/JA8wJ24v/2750-delete-instead-of-truncate-the-table-speakcivicleanupleave